### PR TITLE
`const` should be used over `let`

### DIFF
--- a/getWorkflowRuns.ts
+++ b/getWorkflowRuns.ts
@@ -34,7 +34,7 @@ export const getWorkflowRuns = async () => {
   // Get all the runs
   const run_promises = [];
   for (const repo of repos) {
-    let run = await getInfoFromApi<{workflow_runs: WorkflowRun[]}>(
+    const run = await getInfoFromApi<{workflow_runs: WorkflowRun[]}>(
       "https://api.github.com/repos/NordicSemiconductor/" +
         repo.name +
         "/actions/runs"


### PR DESCRIPTION
`const` should be used over `let` unless it's necessary, which you already did on all the other places. Also the data for `run` isn't getting changed inside the `for` block after it's creation. Therefore, I think it's better to use `const` here as well. :slightly_smiling_face: 